### PR TITLE
Update context-preserves-canvas.html

### DIFF
--- a/imagebitmap-renderingcontext/context-creation-offscreen.html
+++ b/imagebitmap-renderingcontext/context-creation-offscreen.html
@@ -3,7 +3,7 @@
 <title>Canvas's ImageBitmapRenderingContext test</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://html.spec.whatwg.org/multipage/scripting.html#the-imagebitmap-rendering-context">
+ <link rel="help" href="https://html.spec.whatwg.org/multipage/canvas.html#the-imagebitmap-rendering-context">
 <script>
 test(function() {
     var width = 10;

--- a/imagebitmap-renderingcontext/context-creation-offscreen.html
+++ b/imagebitmap-renderingcontext/context-creation-offscreen.html
@@ -5,13 +5,14 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/scripting.html#the-imagebitmap-rendering-context">
 <script>
-var width = 10;
-var height = 10;
-
 test(function() {
-    var canvas = new OffscreenCanvas(60,60);
+    var width = 10;
+    var height = 10;
+    var canvas = new OffscreenCanvas(width, height);
     var ctx = canvas.getContext('bitmaprenderer');
     assert_true(ctx instanceof ImageBitmapRenderingContext);
-}, "Test that canvas.getContext('bitmaprenderer') returns an instance of ImageBitmapRenderingContext");
+    assert_true("canvas" in ctx);
+    assert_object_equals(canvas, ctx.canvas);
+}, "Test that canvas.getContext('bitmaprenderer') returns an instance of ImageBitmapRenderingContext and ctx.canvas on a ImageBitmapRenderingContext returns the original OffscreenCanvas");
 
 </script>

--- a/imagebitmap-renderingcontext/context-preserves-canvas.html
+++ b/imagebitmap-renderingcontext/context-preserves-canvas.html
@@ -3,7 +3,7 @@
 <title>Canvas's ImageBitmapRenderingContext test</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://html.spec.whatwg.org/multipage/scripting.html#the-imagebitmap-rendering-context">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/canvas.html#the-imagebitmap-rendering-context">
 <script>
 var width = 10;
 var height = 10;

--- a/imagebitmap-renderingcontext/context-preserves-canvas.html
+++ b/imagebitmap-renderingcontext/context-preserves-canvas.html
@@ -14,6 +14,8 @@ test(function() {
     canvas.height = height;
     var ctx = canvas.getContext('bitmaprenderer');
     var dstCanvas = ctx.canvas;
+    assert_true("canvas" in ctx);
+    assert_object_equals(canvas, ctx.canvas);
     assert_equals(dstCanvas.width, width);
     assert_equals(dstCanvas.height, height);
 }, "Test that ctx.canvas on a ImageBitmapRenderingContext returns the original canvas");


### PR DESCRIPTION
`ImageBitmapRenderingContext` should have a `canvas` attribute equal to `HTMLCanvasElement` or `OffscreenCanvas` https://html.spec.whatwg.org/multipage/canvas.html#imagebitmaprenderingcontext.

Fixes https://github.com/web-platform-tests/wpt/issues/20769.