### PR TITLE
Fix imagebitmap-renderingcontext/context-preserves-canvas.html

### DIFF
--- a/imagebitmap-renderingcontext/context-preserves-canvas.html
+++ b/imagebitmap-renderingcontext/context-preserves-canvas.html
@@ -5,19 +5,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/canvas.html#the-imagebitmap-rendering-context">
 <script>
-var width = 10;
-var height = 10;
-
 test(function() {
+    var width = 10;
+    var height = 10;
     var canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;
     var ctx = canvas.getContext('bitmaprenderer');
     var dstCanvas = ctx.canvas;
     assert_true("canvas" in ctx);
-    assert_object_equals(canvas, ctx.canvas);
+    assert_equals(canvas, ctx.canvas);
     assert_equals(dstCanvas.width, width);
     assert_equals(dstCanvas.height, height);
 }, "Test that ctx.canvas on a ImageBitmapRenderingContext returns the original canvas");
-
 </script>

--- a/imagebitmap-renderingcontext/context-preserves-canvas.html
+++ b/imagebitmap-renderingcontext/context-preserves-canvas.html
@@ -14,6 +14,7 @@ test(function() {
     var ctx = canvas.getContext('bitmaprenderer');
     var dstCanvas = ctx.canvas;
     assert_true("canvas" in ctx);
+    assert_equals(dstCanvas, ctx.canvas);
     assert_equals(canvas, ctx.canvas);
     assert_equals(dstCanvas.width, width);
     assert_equals(dstCanvas.height, height);


### PR DESCRIPTION
Substitute `assert_equals` or `assert_object_equals`

https://github.com/web-platform-tests/wpt/pull/20776
https://github.com/web-platform-tests/wpt/issues/20844