### PR TITLE
Update worklet-recorder.js

### DIFF
--- a/webaudio/js/worklet-recorder.js
+++ b/webaudio/js/worklet-recorder.js
@@ -8,18 +8,18 @@
 class RecorderProcessor extends AudioWorkletProcessor {
   /**
    * @param {*} options
-   * @param {number} options.duration A duration to record in seconds.
-   * @param {number} options.channelCount A channel count to record.
+   * @param {number} options.processorOption.duration A duration to record in seconds.
+   * @param {number} options.processorOptions.channelCount A channel count to record.
    */
   constructor(options) {
     super();
     this._createdAt = currentTime;
     this._elapsed = 0;
-    this._recordDuration = options.duration || 1;
-    this._recordChannelCount = options.channelCount || 1;
+    this._recordDuration = (options.processorOption && options.processorOptions.duration) || 1;
+    this._recordChannelCount = (options.processorOptions && options.processorOptions.channelCount) || 1;
     this._recordBufferLength = sampleRate * this._recordDuration;
     this._recordBuffer = [];
-    for (let i = 0; i < this._recordChannelCount; ++i) {
+    for (let i = 0; i < this._recordChannelCount; i++) {
       this._recordBuffer[i] = new Float32Array(this._recordBufferLength);
     }
   }
@@ -38,7 +38,7 @@ class RecorderProcessor extends AudioWorkletProcessor {
     // |outputs|.
     const input = inputs[0];
     const output = outputs[0];
-    for (let channel = 0; channel < input.length; ++channel) {
+    for (let channel = 0; channel < this._recordChannelCount; ++channel) {
       const inputChannel = input[channel];
       const outputChannel = output[channel];
       outputChannel.set(inputChannel);


### PR DESCRIPTION
Substitute checking `options.processorOptions.<property>` for `options.<property>` WebAudio/web-audio-api#2011; `this._recordChannelCount` for `input.length` to avoid `cannot read length of undefined` error when `input.length` is greater than `this._recordChannelCount`.

Fixes https://github.com/web-platform-tests/wpt/issues/17662.